### PR TITLE
Change the selector to remove the post timer 

### DIFF
--- a/common/common.scss
+++ b/common/common.scss
@@ -724,6 +724,6 @@ td.poster-names a {
   }
 }
 
-.topic-status-info {
+.topic-timer-info {
   display: none;
 }


### PR DESCRIPTION
As the issue said,

freeCodeCamp/freeCodeCamp#41273

There was a change in discourses css and now the 'This post will be deleted 6 months after the last reply' message reappear. By changing the selector it will remove this.

Fixes freeCodeCamp/freeCodeCamp#41273