### PR TITLE
Fix for Button styling discrepancies issues#41559

### DIFF
--- a/common/common.scss
+++ b/common/common.scss
@@ -188,6 +188,10 @@ p.footer-donation {
   }
 }
 
+div.select-kit-header {
+    margin-bottom: 0 !important;
+}
+
 @media (min-width: 800px) {
   .footer-container {
     width: 750px;
@@ -665,7 +669,7 @@ td.poster-names a {
     padding: 6px 12px;
     font-size: $font-up-1;
     transition: none;
-    height: $--global-nav-height;
+    height: 42px;
     &:hover,
     &:focus {
       color: $fcc-secondary-background;


### PR DESCRIPTION
Overrode margin-bottom default to 0 for select-kit-header and changed the height from 38px to 42px for list-controls combo-box resulting in now even buttons across the selection

Checklist:

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)

Closes #41559
