### PR TITLE
fix: adjust height for nav buttons

### DIFF
--- a/common/common.scss
+++ b/common/common.scss
@@ -621,6 +621,11 @@ td.poster-names a {
   border: none;
 }
 
+// All categories button sizing exception fix
+div.select-kit-header {
+    margin-bottom: 0 !important;
+}
+
 .login-modal,
 .create-account {
   .btn-social {
@@ -665,7 +670,7 @@ td.poster-names a {
     padding: 6px 12px;
     font-size: $font-up-1;
     transition: none;
-    height: $--global-nav-height;
+    height: 42px;
     &:hover,
     &:focus {
       color: $fcc-secondary-background;


### PR DESCRIPTION
Overrode margin-bottom default to 0 for select-kit-header and changed the height from 38px to 42px for list-controls combo-box resulting in now even buttons across the selection

Checklist:

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)

Closes freeCodeCamp/freeCodeCamp#41559