### PR TITLE
fix: embedded styles

### DIFF
--- a/common/embedded.scss
+++ b/common/embedded.scss
@@ -1,3 +1,9 @@
+.discourse-embedding {
+  background-color: #fff;
+  color: $--gray90;
+  overflow-y: auto;
+}
+
 .discourse-embedding .button {
   padding: 0px 14px;
   outline: none;
@@ -10,7 +16,7 @@
   background-image: linear-gradient(#fecc4c, #ffac33);
   border: 3px solid #feac32;
   color: var(--theme-color);
-  display: flex;
+  display: inline-flex;
   align-items: center;
 }
 
@@ -28,4 +34,8 @@
   background-image: none;
   box-shadow: inset 0 1px 4px rgba(0, 0, 0, 0.3);
   text-decoration: none;
+}
+
+.discourse-embedding footer .logo {
+  display: none;
 }

--- a/common/embedded.scss
+++ b/common/embedded.scss
@@ -1,31 +1,31 @@
 .discourse-embedding .button {
-    padding: 0px 14px;
-    outline: none;
-    cursor: pointer;
-    margin-right: 5px;
-    height: 30px;
-    line-height: 24px; /* centers the text for all browser font sizes */
-    text-decoration: none;
-    background-color: #feac32;
-    background-image: linear-gradient(#fecc4c, #ffac33);
-    border: 3px solid #feac32;
-    color: var(--theme-color);
-    display: flex;
-    align-items: center;
-  }
-  
-  .discourse-embedding .button:hover,
-  .discourse-embedding .button:focus,
-  .discourse-embedding .button:active:hover {
-    background-color: #fecc4c;
-    border-width: 3px;
-    border-color: #f1a02a;
-    background-image: none;
-    color: var(--theme-color);
-    text-decoration: none;
-  }
-  .discourse-embedding .button:active {
-    background-image: none;
-    box-shadow: inset 0 1px 4px rgba(0, 0, 0, 0.3);
-    text-decoration: none;
-  }
+  padding: 0px 14px;
+  outline: none;
+  cursor: pointer;
+  margin-right: 5px;
+  height: 30px;
+  line-height: 24px; /* centers the text for all browser font sizes */
+  text-decoration: none;
+  background-color: #feac32;
+  background-image: linear-gradient(#fecc4c, #ffac33);
+  border: 3px solid #feac32;
+  color: var(--theme-color);
+  display: flex;
+  align-items: center;
+}
+
+.discourse-embedding .button:hover,
+.discourse-embedding .button:focus,
+.discourse-embedding .button:active:hover {
+  background-color: #fecc4c;
+  border-width: 3px;
+  border-color: #f1a02a;
+  background-image: none;
+  color: var(--theme-color);
+  text-decoration: none;
+}
+.discourse-embedding .button:active {
+  background-image: none;
+  box-shadow: inset 0 1px 4px rgba(0, 0, 0, 0.3);
+  text-decoration: none;
+}


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Related to https://github.com/freeCodeCamp/news-theme/pull/121

<!-- Feel free to add any additional description of changes below this line -->
This PR adjusts some of the styles for the Discourse comments `iframe` for Chinese News.

Here's what they look like now: 
![image](https://user-images.githubusercontent.com/2051070/122893086-f4b96f00-d380-11eb-95c5-fc365d7311b6.png)

And this is what they should look like after these updates:
![image](https://user-images.githubusercontent.com/2051070/122893345-3813dd80-d381-11eb-9c0e-c798ae32a678.png)

But I wasn't able to test this locally due to CORS issues. Instead I used the dev console to play with the different styles.