### PR TITLE
fix: freeCodeCamp/freeCodeCamp#41273

### DIFF
--- a/common/common.scss
+++ b/common/common.scss
@@ -736,6 +736,6 @@ div.select-kit-header {
   }
 }
 
-.topic-status-info {
+.topic-timer-heading > span {
   display: none;
 }


### PR DESCRIPTION
Discourse rolled out an update which included a small breaking change for our forum theme. The "This topic will close in 6 months" message box is visible at the bottom of each topic again, this is a fix of that update

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes freeCodeCamp/freeCodeCamp#41273

<!-- Feel free to add any additional description of changes below this line -->

Discourse rolled out an update which included a small breaking change for our forum theme. The "This topic will close in 6 months" message box is visible at the bottom of each topic again, this is a fix
