### PR TITLE
fix: category dropdown

### DIFF
--- a/common/common.scss
+++ b/common/common.scss
@@ -825,9 +825,17 @@ div.select-kit-header {
   background-color: $fcc-d-hover;
 }
 
-// Dropdown items
+// Dropdown
+.select-kit-header {
+  color: $fcc-primary-color $i;
+}
+
+.select-kit-header:hover,
+.select-kit.is-expanded .select-kit-header,
 .select-kit-row.is-highlighted,
-.select-kit-row.is-selected, {
+.select-kit-row.is-selected, 
+.select-kit-row.is-highlighted a,
+.select-kit-row.is-highlighted span {
   background-color: $primary $i;
-  color: $fcc-quaternary-background $i;
+  color: $primary-low $i;
 }


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a [descriptive title](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request?id=prepare-a-good-pr-title) (**not** a vague title like `Update index.md`)

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Fixes a couple of issues in the Category dropdown:
- The dropdown color is lighter than the rest of the buttons.
  - <img width="651" alt="Screenshot 2024-03-19 at 14 14 32" src="https://github.com/freeCodeCamp/forum-theme/assets/25715018/f030ac8b-0da2-4b7c-a206-bf557efc92c2">
- Dropdown items text doesn't have sufficient contrast against the background.
  - <img width="654" alt="Screenshot 2024-03-19 at 15 11 56" src="https://github.com/freeCodeCamp/forum-theme/assets/25715018/c9380845-fa23-4b18-9c3c-3539d48ccea3">

## Results

<details>
  <summary>Screenshots</summary>

### At rest
| Theme | Screenshot |
| --- | --- |
| Day | <img width="722" alt="Screenshot 2024-03-19 at 23 31 16" src="https://github.com/freeCodeCamp/forum-theme/assets/25715018/1ae67a4f-a202-4c84-8f1e-b856c66af67b"> |
| Dawn | <img width="722" alt="Screenshot 2024-03-19 at 23 33 24" src="https://github.com/freeCodeCamp/forum-theme/assets/25715018/14368b75-2ab7-4e1f-8be1-d23469d5f534"> |
| Night | <img width="732" alt="Screenshot 2024-03-19 at 23 32 41" src="https://github.com/freeCodeCamp/forum-theme/assets/25715018/43ccd5e0-83de-4a1e-b8b1-98831c6c0723"> |

### Expanded and hovered

| Theme | Screenshot |
| --- | --- |
| Day | <img width="735" alt="Screenshot 2024-03-19 at 14 09 44" src="https://github.com/freeCodeCamp/forum-theme/assets/25715018/c1db96e6-ac47-4616-a1af-54c336a1fa52"> |
| Dawn | <img width="734" alt="Screenshot 2024-03-19 at 14 10 41" src="https://github.com/freeCodeCamp/forum-theme/assets/25715018/fd8c9a02-04ce-4add-b20f-0ca220368de7"> |
| Night | <img width="731" alt="Screenshot 2024-03-19 at 14 10 14" src="https://github.com/freeCodeCamp/forum-theme/assets/25715018/fb42b629-fcb5-4799-822b-0111dba3f621"> |

</details>

<!-- Feel free to add any additional description of changes below this line -->
