### PR TITLE
fix: profile quick access panel

### DIFF
--- a/common/common.scss
+++ b/common/common.scss
@@ -816,13 +816,17 @@ div.select-kit-header {
 }
 
 // Adjust hover and read(selected) states
-.user-menu .quick-access-panel li {
- background-color: $fcc-d-selected;
-}
-
 .user-menu .quick-access-panel li:hover,
 .menu-panel .widget-link:hover, .menu-panel .widget-link:focus, .menu-panel .categories-link:hover, .menu-panel .categories-link:focus {
-  background-color: $fcc-d-hover;
+  background-color: $fcc-d-hover $i;
+}
+
+.user-menu .quick-access-panel li button {
+  border: none;
+
+  &:hover {
+    background-color: transparent $i;
+  }
 }
 
 // Dropdown items


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a [descriptive title](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request?id=prepare-a-good-pr-title) (**not** a vague title like `Update index.md`)

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

This PR: Fixes the following issues in the Profile Quick Access panel:
- Fixes the styles of the bottom 2 buttons so that they match the rest
- Removes background color from the items, so that they don't look contained / packed in a box

## Screenshots

### Before

<details>
  <summary>Screenshot</summary>
  <img width="393" alt="Screenshot 2024-03-21 at 23 05 07" src="https://github.com/freeCodeCamp/forum-theme/assets/25715018/af2bb14a-10dd-4e25-ad3f-de1c166f1a46">
</details>

### After

<details>
  <summary>Screenshot</summary>

  | Theme | Screenshot |
  | --- | --- |
  | Day | <img width="396" alt="Screenshot 2024-03-21 at 23 49 34" src="https://github.com/freeCodeCamp/forum-theme/assets/25715018/910b007a-743e-4ea8-a0cd-12caa0682e1a"> |
  | Dark | <img width="400" alt="Screenshot 2024-03-21 at 23 45 55" src="https://github.com/freeCodeCamp/forum-theme/assets/25715018/35641e59-dfb5-4250-a296-5d68d9f56dbf"> |
  | Dawn | <img width="395" alt="Screenshot 2024-03-21 at 23 48 13" src="https://github.com/freeCodeCamp/forum-theme/assets/25715018/b620a63c-cd42-4a79-96ec-c0914e3c3e68"> |

</details>

<!-- Feel free to add any additional description of changes below this line -->
