### PR TITLE
fix: standardize focus outline style

### DIFF
--- a/common/common.scss
+++ b/common/common.scss
@@ -32,6 +32,7 @@ $n: none;
 $i: !important;
 $--global-nav-height: 38px;
 $--dark-blue: #002ead;
+$--blue-50: #198eee;
 $header_primary: #fff;
 $header_background: #0a0a23;
 $--gray90: mix($header_background, $header_primary, 100%);
@@ -94,10 +95,27 @@ $breakpoints: (
 @import url("https://fonts.googleapis.com/css?family=Lato:400,400i,700");
 @import url("https://fonts.googleapis.com/css?family=Roboto+Mono:400,400i,700");
 
+// focus outline mixin ---------------------------------------------------------------
+
+@mixin focus-outline {
+  outline: 3px solid $--blue-50 $i;
+  outline-offset: 0 $i;
+}
+
 // general ---------------------------------------------------------------
 html {
   font-family: "Lato", sans-serif;
   font-size: 18px;
+}
+
+:focus-visible {
+  @include focus-outline;
+}
+
+@supports not selector(:focus-visible) {
+  :focus {
+    @include focus-outline;
+  }
 }
 
 /* Footer ---------------------------------------------------------- */
@@ -790,6 +808,12 @@ div.select-kit-header {
 
   a.title.visited:not(.badge-notification) {
     color: $primary-medium;
+  }
+}
+
+.topic-list .main-link {
+  &.focused {
+    box-shadow: none $i; /* Unset the default Discourse styles */
   }
 }
 


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a [descriptive title](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request?id=prepare-a-good-pr-title) (**not** a vague title like `Update index.md`)

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

This PR sets a custom focus outline to the forum theme in order to make its display consistent across browsers.

## Result

![focus-outline](https://github.com/freeCodeCamp/forum-theme/assets/25715018/57501285-a310-4bf3-ac3b-42b0342824ab)

Note: The Categories button looks a little off, and I have #117 to address that separately.

<!-- Feel free to add any additional description of changes below this line -->
