### PR TITLE
FIX: Increase header icon rule specificity

### DIFF
--- a/common/common.scss
+++ b/common/common.scss
@@ -428,7 +428,7 @@ body.no-ember {
   background-color: $--gray75;
 }
 
-.d-header-icons .d-icon {
+.d-header-icons .btn .d-icon {
   color: $--gray65;
 }
 


### PR DESCRIPTION
A side effect of the recent header upgrade was to introduce the `.btn` class on the header buttons. That means they are now subject to the `color: inherit` rule on line 557 of this theme's css.

This commit increases the specificity of the header icon selector so that it 'wins' over the more general `color: inherit` rule.

This should fix the icon color problems under the 'day' theme on freecodecamp.

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [ ] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [ ] My pull request has a [descriptive title](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request?id=prepare-a-good-pr-title) (**not** a vague title like `Update index.md`)

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->
