### PR TITLE
fix: pad the search box evenly

### DIFF
--- a/common/common.scss
+++ b/common/common.scss
@@ -554,7 +554,7 @@ a.curriculum-nav:focus {
 .btn:hover .d-icon,
 .btn .d-icon,
 .btn-primary .d-icon {
-  color: inherit $i;
+  color: inherit;
 }
 
 .d-header-icons .badge-notification {
@@ -862,6 +862,14 @@ div.select-kit-header {
   // so we need to remove ours to avoid having nested focus outlines.
   #search-term:focus-visible {
     outline: none $i;
+  }
+
+  .btn.show-advanced-search {
+    margin-right: 0.5em;
+  }
+
+  .btn.show-advanced-search .d-icon {
+    color: inherit;
   }
 }
 


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a [descriptive title](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request?id=prepare-a-good-pr-title) (**not** a vague title like `Update index.md`)

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

This PR:
- Adds a right margin to the advanced search button so that the padding of the search box looks even
- Replaces an `$i` flag that was added by #124 with class selector (I'm trying to avoid using the `!important` flag)

## Screenshot

| Before | After |
| --- | --- |
| <img width="482" alt="Screenshot 2024-04-23 at 12 20 17" src="https://github.com/freeCodeCamp/forum-theme/assets/25715018/33460ea9-28c1-4752-8589-f2adabbdc23c"> | <img width="486" alt="Screenshot 2024-04-23 at 12 19 56" src="https://github.com/freeCodeCamp/forum-theme/assets/25715018/e92d931c-94b2-4781-b5ea-25276922d518"> |

<!-- Feel free to add any additional description of changes below this line -->
