### PR TITLE
fix: group trending guides in a ul

### DIFF
--- a/common/common.scss
+++ b/common/common.scss
@@ -129,12 +129,13 @@ html {
 .footer-container {
   margin-right: auto;
   margin-left: auto;
-  padding-left: 15px;
   padding-right: 15px;
+  padding-left: 15px;
   padding-top: 40px;
   padding-bottom: 40px;
   font-size: 16px;
   overflow-x: hidden;
+  width: min(100%, 1300px);
 }
 
 .footer-container p {
@@ -168,24 +169,9 @@ html {
   margin: 0px;
 }
 
-.footer-col {
-  display: flex;
-  flex-direction: column;
-  flex: 0 0 100%;
-  padding-left: 15px;
-  padding-right: 15px;
-  font-size: 16px;
-}
-
-.footer-right,
-.footer-left {
-  display: flex;
-  flex-direction: column;
-  flex: 0 0 100%;
-}
-
-.footer-col a {
-  padding: 5px 0px;
+.footer-top {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(19em, 1fr));
 }
 
 .footer-desc-col {
@@ -230,44 +216,30 @@ p.footer-donation {
   padding: 5px 10px;
 }
 
+.trending-guides-articles {
+  list-style-type: none;
+  padding: 0;
+  margin: 0;
+  display: grid;
+  grid-column-gap: 2rem;
+  grid-row-gap: 0.5rem;
+}
+
 @include at-least(screen-sm-min) {
-  .trending-guides-row {
-    display: flex;
-    flex-direction: row;
-    flex-wrap: wrap;
-  }
-  .footer-col-3 {
-    flex: 1 0 100%;
-    flex-direction: row;
+  .footer-top {
+    grid-template-columns: repeat(auto-fit, minmax(30.5em, 1fr));
   }
 
-  .footer-col-1,
-  .footer-col-2,
-  .footer-right,
-  .footer-left {
-    flex: 1 0 43%;
-    height: auto;
-    font-size: 15;
+  .trending-guides-articles {
+    grid-template-columns: repeat(auto-fit, minmax(13em, 1fr));
   }
 }
 
 @include at-least(screen-md-min) {
-  .footer-container {
-    width: 750px;
+  .trending-guides-articles {
+    grid-template-columns: repeat(auto-fit, minmax(12em, 1fr));
   }
-  .footer-col-1,
-  .footer-col-2,
-  .footer-col-3 {
-    flex: 1 0 25%;
-    height: auto;
-    font-size: 16.5;
-  }
-  .footer-col-3 {
-    flex-direction: column;
-  }
-  .footer-right {
-    padding-left: 0px;
-  }
+
   .footer-container .col-spacer {
     margin-top: 40px;
   }
@@ -277,34 +249,17 @@ p.footer-donation {
 }
 
 @include at-least(screen-xl-min) {
-  .footer-container {
-    width: 850px;
+  .trending-guides-articles {
+    grid-template-columns: repeat(auto-fit, minmax(11em, 1fr));
   }
 }
 
 @include at-least(screen-xxl-min) {
-  .footer-container {
-    width: 1170px;
-  }
-  .footer-top {
-    display: flex;
-    flex-direction: row;
-  }
   .footer-desc-col {
     flex: 1 0 45%;
   }
   .trending-guides {
     flex: 1 0 58%;
-  }
-
-  .footer-col-1 {
-    flex: 1 0 22%;
-  }
-  .footer-col-3 {
-    flex: 1 0 30%;
-  }
-  .footer-col-2 {
-    flex: 1 0 18%;
   }
 
   p.footer-donation {

--- a/common/head_tag.html
+++ b/common/head_tag.html
@@ -23,142 +23,159 @@
             </div>
             
             <div class="trending-guides">
-              <div class="col-header">{{theme-setting 'footer_columns_header'}}</div>
-              <div class="trending-guides-row">
-                <div class="footer-col footer-col-1">
-                  <a
-                    href={{theme-setting 'article0link'}}
-                    >{{theme-setting 'article0title'}}</a
-                  >
-                  <a
-                    href={{theme-setting 'article1link'}}
-                    >{{theme-setting 'article1title'}}</a
-                  >
-                  <a
-                    href={{theme-setting 'article2link'}}
-                    >{{theme-setting 'article2title'}}</a
-                  >
-                  <a
-                    href={{theme-setting 'article3link'}}
-                    >{{theme-setting 'article3title'}}</a
-                  >
-                  <a
-                    href={{theme-setting 'article4link'}}
-                    >{{theme-setting 'article4title'}}</a
-                  >
-                  <a
-                    href={{theme-setting 'article5link'}}
-                    >{{theme-setting 'article5title'}}</a
-                  >
-                  <a
-                    href={{theme-setting 'article6link'}}
-                    >{{theme-setting 'article6title'}}</a
-                  >
-                  <a
-                    href={{theme-setting 'article7link'}}
-                    >{{theme-setting 'article7title'}}</a
-                  >
-                  <a
-                    href={{theme-setting 'article8link'}}
-                    >{{theme-setting 'article8title'}}</a
-                  >
-                  <a
-                    href={{theme-setting 'article9link'}}
-                    >{{theme-setting 'article9title'}}</a
-                  >
-                </div>
-                <div class="footer-col footer-col-2">
-                    <a
-                    href={{theme-setting 'article10link'}}
-                    >{{theme-setting 'article10title'}}</a
-                  >
-                  <a
-                    href={{theme-setting 'article11link'}}
-                    >{{theme-setting 'article11title'}}</a
-                  >
-                  <a
-                    href={{theme-setting 'article12link'}}
-                    >{{theme-setting 'article12title'}}</a
-                  >
-      
-                  <a
-                    href={{theme-setting 'article13link'}}
-                    >{{theme-setting 'article13title'}}</a
-                  >
-                  <a
-                    href={{theme-setting 'article14link'}}
-                    >{{theme-setting 'article14title'}}</a
-                  >
-                  <a
-                    href={{theme-setting 'article15link'}}
-                    >{{theme-setting 'article15title'}}</a
-                  >
-                  <a
-                    href={{theme-setting 'article16link'}}
-                    >{{theme-setting 'article16title'}}</a
-                  >
-                  <a
-                    href={{theme-setting 'article17link'}}
-                    >{{theme-setting 'article17title'}}</a
-                  >
-                  <a
-                    href={{theme-setting 'article18link'}}
-                    >{{theme-setting 'article18title'}}</a
-                  >
-                  <a
-                    href={{theme-setting 'article19link'}}
-                    >{{theme-setting 'article19title'}}</a
-                  >
-                </div>
-                <div class="footer-col footer-col-3">
-                  <div class="footer-left">
-                    <a
-                    href={{theme-setting 'article20link'}}
-                    >{{theme-setting 'article20title'}}</a
-                  >
-                  <a
-                    href={{theme-setting 'article21link'}}
-                    >{{theme-setting 'article21title'}}</a
-                  >
-                  <a
-                    href={{theme-setting 'article22link'}}
-                    >{{theme-setting 'article22title'}}</a
-                  >
-      
-                  <a
-                    href={{theme-setting 'article23link'}}
-                    >{{theme-setting 'article23title'}}</a
-                  >
-                  <a
-                    href={{theme-setting 'article24link'}}
-                    >{{theme-setting 'article24title'}}</a
-                  >
-                  </div>
-      
-                  <div class="footer-right">
-                    <a
-                    href={{theme-setting 'article25link'}}
-                    >{{theme-setting 'article25title'}}</a
-                  >
-                  <a
-                    href={{theme-setting 'article26link'}}
-                    >{{theme-setting 'article26title'}}</a
-                  >
-                  <a
-                    href={{theme-setting 'article27link'}}
-                    >{{theme-setting 'article27title'}}</a
-                  >
-                  <a
-                    href={{theme-setting 'article28link'}}
-                    >{{theme-setting 'article28title'}}</a
-                  >
-                  <a
-                    href={{theme-setting 'article29link'}}
-                    >{{theme-setting 'article29title'}}</a
-                  >
-                  </div>
-                </div>
-              </div>
+              <h2 id="trending-guides" class="col-header">{{theme-setting 'footer_columns_header'}}</h2>              
+              <ul aria-labelledby="trending-guides" class="trending-guides-articles">
+                <li>
+                  <a href={{theme-setting 'article0link'}}>
+                    {{theme-setting 'article0title'}}
+                  </a>
+                </li>
+                <li>  
+                  <a href={{theme-setting 'article1link'}}>
+                    {{theme-setting 'article1title'}}
+                  </a>
+                </li>
+                <li>
+                  <a href={{theme-setting 'article2link'}}>
+                    {{theme-setting 'article2title'}}
+                  </a>
+                </li>  
+                <li>
+                  <a href={{theme-setting 'article3link'}}>
+                    {{theme-setting 'article3title'}}
+                  </a>
+                </li>
+                <li>
+                  <a href={{theme-setting 'article4link'}}>
+                    {{theme-setting 'article4title'}}
+                  </a>
+                </li>
+                <li>
+                  <a href={{theme-setting 'article5link'}}>
+                    {{theme-setting 'article5title'}}
+                  </a>
+                </li>
+                <li>  
+                  <a href={{theme-setting 'article6link'}}>
+                    {{theme-setting 'article6title'}}
+                  </a>
+                </li>
+                <li>  
+                  <a href={{theme-setting 'article7link'}}>
+                    {{theme-setting 'article7title'}}
+                  </a>
+                </li>
+                <li>  
+                  <a href={{theme-setting 'article8link'}}>
+                    {{theme-setting 'article8title'}}
+                  </a>
+                </li>
+                <li>
+                  <a href={{theme-setting 'article9link'}}>
+                    {{theme-setting 'article9title'}}
+                  </a>
+                </li>
+                <li>  
+                  <a href={{theme-setting 'article10link'}}>
+                    {{theme-setting 'article10title'}}
+                  </a>
+                </li>
+                <li>  
+                  <a href={{theme-setting 'article11link'}}>
+                    {{theme-setting 'article11title'}}
+                  </a>
+                </li>
+                <li>  
+                  <a href={{theme-setting 'article12link'}}>
+                    {{theme-setting 'article12title'}}
+                  </a>
+                </li>
+                <li>
+                  <a href={{theme-setting 'article13link'}}>
+                    {{theme-setting 'article13title'}}
+                  </a>
+                </li>
+                <li>
+                  <a href={{theme-setting 'article14link'}}>
+                    {{theme-setting 'article14title'}}
+                  </a>
+                </li>
+                <li>  
+                  <a href={{theme-setting 'article15link'}}>
+                    {{theme-setting 'article15title'}}
+                  </a>
+                </li>
+                <li>  
+                  <a href={{theme-setting 'article16link'}}>
+                    {{theme-setting 'article16title'}}
+                  </a>
+                </li>
+                <li>  
+                  <a href={{theme-setting 'article17link'}}>
+                    {{theme-setting 'article17title'}}
+                  </a>
+                </li>
+                <li>
+                  <a href={{theme-setting 'article18link'}}>
+                    {{theme-setting 'article18title'}}
+                  </a>
+                </li>  
+                <li>
+                  <a href={{theme-setting 'article19link'}}>
+                    {{theme-setting 'article19title'}}
+                  </a>
+                </li>
+                <li>  
+                  <a href={{theme-setting 'article20link'}}>
+                    {{theme-setting 'article20title'}}
+                  </a>
+                </li>
+                <li>  
+                  <a href={{theme-setting 'article21link'}}>
+                    {{theme-setting 'article21title'}}
+                  </a>
+                </li>
+                <li>  
+                  <a href={{theme-setting 'article22link'}}>
+                    {{theme-setting 'article22title'}}
+                  </a>
+                </li>
+                <li>
+                  <a href={{theme-setting 'article23link'}}>
+                    {{theme-setting 'article23title'}}
+                  </a>
+                </li>
+                <li>  
+                  <a href={{theme-setting 'article24link'}}>
+                    {{theme-setting 'article24title'}}
+                  </a>
+                </li>
+                <li>
+                  <a href={{theme-setting 'article25link'}}>
+                    {{theme-setting 'article25title'}}
+                  </a>
+                </li>
+                <li>  
+                  <a href={{theme-setting 'article26link'}}>
+                    {{theme-setting 'article26title'}}
+                  </a>
+                </li>
+                <li>  
+                  <a href={{theme-setting 'article27link'}}>
+                    {{theme-setting 'article27title'}}
+                  </a>
+                </li>
+                <li>  
+                  <a href={{theme-setting 'article28link'}}>
+                    {{theme-setting 'article28title'}}
+                  </a>
+                </li>  
+                <li>
+                  <a href={{theme-setting 'article29link'}}>
+                    {{theme-setting 'article29title'}}
+                  </a>
+                </li>  
+              </ul>
             </div>
           </div>
           <div class="footer-buttom">


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a [descriptive title](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request?id=prepare-a-good-pr-title) (**not** a vague title like `Update index.md`)

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

This PR:
- Groups items in the Trending Guides section in a `ul` (closes https://github.com/freeCodeCamp/freeCodeCamp/issues/52189)
- Updates and cleans up the CSS as the DOM structure is different now

<details>
  <summary>Screenshots</summary>

  | Device | Screenshot |
  | --- | --- |
  | Desktop | <img width="1680" alt="Screenshot 2024-04-23 at 14 25 13" src="https://github.com/freeCodeCamp/forum-theme/assets/25715018/44180a24-b75d-4bb5-882f-416c9098a3a1"> |
  | Tablet | <img width="865" alt="Screenshot 2024-04-23 at 14 26 26" src="https://github.com/freeCodeCamp/forum-theme/assets/25715018/a0c883e7-0c13-4b66-98d9-c386dafe3963"> |
  | Phone | <img width="738" alt="Screenshot 2024-04-23 at 14 26 56" src="https://github.com/freeCodeCamp/forum-theme/assets/25715018/f1e40cf3-6b05-4d73-98e5-79a428a3b439"> |
</details>



<!-- Feel free to add any additional description of changes below this line -->
