### PR TITLE
fix: multiple issues in link styles

### DIFF
--- a/common/common.scss
+++ b/common/common.scss
@@ -689,6 +689,11 @@ div.select-kit-header {
       background-color: $primary;
       border: 3px solid $primary;
     }
+
+    // This pseudo element is a blue underline.
+    a.active::after {
+      display: none;
+    }
   }
 }
 

--- a/common/common.scss
+++ b/common/common.scss
@@ -694,6 +694,18 @@ div.select-kit-header {
     a.active::after {
       display: none;
     }
+
+    a .d-icon,
+    button .d-icon {
+      transition: none; // Disable the default delay in color change when the icon is hovered
+    }
+
+    a.active .d-icon,
+    a:hover .d-icon,
+    button.active .d-icon,
+    button:hover .d-icon {
+      color: inherit;
+    }
   }
 }
 

--- a/common/common.scss
+++ b/common/common.scss
@@ -843,3 +843,9 @@ div.select-kit-header {
     background-color: $fcc-d-hover;
   }
 }
+
+// Categories sidebar
+.sidebar-section-link-wrapper .sidebar-section-link:hover,
+.sidebar-section-link-wrapper .sidebar-section-link.active {
+  color: $primary-low;
+}


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a [descriptive title](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request?id=prepare-a-good-pr-title) (**not** a vague title like `Update index.md`)

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

This PR fixes the following issues:
- Text color of active sidebar items not having sufficient contrast
- Active link having a blue underline (this apparently came from a Discourse change. Having the underline isn't a big deal, but I think it's redundant)
- Some link icons are in blue instead of using the link text color

<details>
  <summary>Screenshots</summary>

  | Issue | Before | After |
  | --- | --- | --- |
  | Sidebar item | <img width="349" alt="Screenshot 2024-07-05 at 15 44 20" src="https://github.com/freeCodeCamp/forum-theme/assets/25715018/e713fd0f-6db5-431b-8553-63eddc17d941"> | <img width="348" alt="Screenshot 2024-07-05 at 15 50 16" src="https://github.com/freeCodeCamp/forum-theme/assets/25715018/9ad7b44b-e95d-4e36-95aa-d0ecceac5254"> |
  | Link underline | <img width="439" alt="Screenshot 2024-07-05 at 16 22 32" src="https://github.com/freeCodeCamp/forum-theme/assets/25715018/c20fb8c8-d71f-4f9a-ac75-016457a6c625"> | <img width="435" alt="Screenshot 2024-07-05 at 16 23 09" src="https://github.com/freeCodeCamp/forum-theme/assets/25715018/6a2b4c45-3e13-4803-8c09-c35e0f7cfb6e"> |
  | Link icon | <img width="1120" alt="Screenshot 2024-07-05 at 16 43 45" src="https://github.com/freeCodeCamp/forum-theme/assets/25715018/2f1b9f67-2f52-4ab2-a683-37d84212e94d"> | <img width="1093" alt="Screenshot 2024-07-05 at 16 44 03" src="https://github.com/freeCodeCamp/forum-theme/assets/25715018/eea67d7e-1452-4f05-bbef-e6a24fb02d87"> |
</details>

<!-- Feel free to add any additional description of changes below this line -->
