### PR TITLE
fix: alt text of nav logo

### DIFF
--- a/javascripts/discourse/api-initializers/freecodecamp.gjs
+++ b/javascripts/discourse/api-initializers/freecodecamp.gjs
@@ -18,7 +18,7 @@ export default apiInitializer("0.8", (api) => {
             id="site-logo"
             class="logo-big"
             src={{siteSettings.site_logo_url}}
-            alt={{settings.title}}
+            alt={{siteSettings.title}}
           />
         </a>
       </div>


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a [descriptive title](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request?id=prepare-a-good-pr-title) (**not** a vague title like `Update index.md`)

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

I just found that the nav logo doesn't have an alt text.

I think we accidentally dropped it when we changed the header implementation: https://github.com/freeCodeCamp/forum-theme/pull/120/files#diff-b4a20fd576119e4371738cb066fea405f31afa7cda9db845dc0bf1815a5bc94aL24.

<!-- Feel free to add any additional description of changes below this line -->
