### PR TITLE
chore: make menu smaller

### DIFF
--- a/common/common.scss
+++ b/common/common.scss
@@ -826,3 +826,7 @@ div.select-kit-header {
 .sidebar-section-link-wrapper .sidebar-section-link.active {
   color: var(--primary-low);
 }
+
+.hamburger-panel .revamped {
+	--d-sidebar-row-height: 1.5em;
+}


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [X] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [X] My pull request has a [descriptive title](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request?id=prepare-a-good-pr-title) (**not** a vague title like `Update index.md`)

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes https://github.com/freeCodeCamp/freeCodeCamp/issues/57276

<!-- Feel free to add any additional description of changes below this line -->
This roughly changes the line height of the menu to be `24px` which should make it not so close to the bottom of the page. 

The original value was `30px`.  