### PR TITLE
fix: remove flex from list controls

### DIFF
--- a/common/common.scss
+++ b/common/common.scss
@@ -676,7 +676,6 @@ div.select-kit-header {
 .list-controls {
   clear: both;
   margin-bottom: 5px;
-  display:flex; 
   .combo-box .combo-box-header {
     background: var(--secondary);
     color: var(--primary);


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [X] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [X] My pull request has a [descriptive title](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request?id=prepare-a-good-pr-title) (**not** a vague title like `Update index.md`)

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #144

<!-- Feel free to add any additional description of changes below this line -->


Replacement for https://github.com/freeCodeCamp/forum-theme/pull/145. 

Removes `display:flex` from the `list-controls` class. 