### PR TITLE
chore(ui): use better sidebar color

### DIFF
--- a/common/common.scss
+++ b/common/common.scss
@@ -832,7 +832,7 @@ div.select-kit-header {
 // Categories sidebar
 .sidebar-section-link-wrapper .sidebar-section-link:hover,
 .sidebar-section-link-wrapper .sidebar-section-link.active {
-  color: var(--primary-low);
+  color: var(--primary);
 }
 
 .hamburger-panel .revamped {


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [X] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [X] My pull request has a [descriptive title](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request?id=prepare-a-good-pr-title) (**not** a vague title like `Update index.md`)

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->

![screenshot using dev tools on the live forum](https://github.com/user-attachments/assets/ad1358af-a094-4a3d-9e9d-814aab0290eb)


I adjust the color used in the hover CSS to make it a lot easier to see. Due to all of the darkness nearby, it's a lot harder to read the black on grey. 
