### PR TITLE
fix: show navigation panel

### DIFF
--- a/common/common.scss
+++ b/common/common.scss
@@ -66,6 +66,11 @@ $breakpoints: (
 }
 
 // general ---------------------------------------------------------------
+:root {
+  --header-offset: {$--header-offset};
+  --global-nav-height: {$--global-nav-height}; 
+}
+
 html {
   font-family: "Lato", sans-serif;
   font-size: 18px;


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [X] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [X] My pull request has a [descriptive title](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request?id=prepare-a-good-pr-title) (**not** a vague title like `Update index.md`)

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes https://github.com/freeCodeCamp/freeCodeCamp/issues/68179

<!-- Feel free to add any additional description of changes below this line -->
It has to do with a CSS variable not being set. In this case `--header-offset`.  I found this variable (while using safe-mode) on the `#ember3` element. I'm sticking it on the root because it was convenient for me. 

https://meta.discourse.org/t/using-safe-mode-to-troubleshoot-issues-with-themes-and-plugins/53504